### PR TITLE
Fix path of alias in Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function preprocessorFactory(config) {
       const regex = new RegExp(`^${alias.key}$|^${alias.key}(\\/)`);
 
       if (regex.test(require)) {
-        return path.normalize(require.replace(regex, `${alias.value}$1`));
+        return path.normalize(require.replace(regex, `${alias.value}$1`)).replace(/\\/g,'/');
       }
     }
 


### PR DESCRIPTION
In Windows path.normalize() doesn't work to generate source code because the double backslash `(C:\\user\\program\\node_modules\\package)` turns in single backslash `(C:\user\program\node_modules\package)` when the source code is read, wich require doesn't understand. So, it is better use normal slash.